### PR TITLE
locationtech dependency improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,14 @@
                         <artifactId>commons-lang3</artifactId>
                         <groupId>org.apache.commons</groupId>
                     </exclusion>
+                    <exclusion>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                        <groupId>org.bouncycastle</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>json-lib</artifactId>
+                        <groupId>net.sf.json-lib</groupId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
* Add explicit dependency on `geowave-core-store` and `geowave-core-index`
* Add additional exclusions for these dependencies for things.

Ultimately, the transitive dependency on bcprov-jdk15on led me here, but the `dependency:analyze` plugin helped show me the way.