### PR TITLE
Introduce Type Descriptions Into Classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,12 @@
         <dependency>
             <groupId>org.locationtech.geowave</groupId>
             <artifactId>geowave-core-geotime</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-reload4j</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.locationtech.jts</groupId>

--- a/src/main/java/datawave/data/type/AbstractGeometryType.java
+++ b/src/main/java/datawave/data/type/AbstractGeometryType.java
@@ -9,8 +9,8 @@ import org.locationtech.jts.geom.Polygon;
 
 import datawave.data.normalizer.DiscreteIndexNormalizer;
 import datawave.data.normalizer.Normalizer;
-import datawave.data.normalizer.OneToManyNormalizer;
 import datawave.data.type.util.AbstractGeometry;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
 /**
  * The base GeoWave geometry type, which provides an implementation for the discrete index type interface.
@@ -18,12 +18,14 @@ import datawave.data.type.util.AbstractGeometry;
  * @param <T>
  *            The underlying geometry type
  */
-public abstract class AbstractGeometryType<T extends AbstractGeometry & Comparable<T>> extends BaseType<T> implements DiscreteIndexType<T> {
+public abstract class AbstractGeometryType<T extends AbstractGeometry & Comparable<T>> extends BaseType<T>
+                implements DiscreteIndexType<T>, TypePrettyNameSupplier {
     
     private static final long GEOMETRY_FACTORY_SIZE = 120;
     private static final long ENVELOPE_SIZE = 45;
     private static final long GEOMETRY_BASE_SIZE = ENVELOPE_SIZE + 20;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE + GEOMETRY_FACTORY_SIZE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Abstract Geometry";
     
     public AbstractGeometryType(Normalizer<T> normalizer) {
         super(normalizer);
@@ -95,5 +97,10 @@ public abstract class AbstractGeometryType<T extends AbstractGeometry & Comparab
                             + Sizer.REFERENCE;
         }
         return size;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/DateType.java
+++ b/src/main/java/datawave/data/type/DateType.java
@@ -3,11 +3,13 @@ package datawave.data.type;
 import java.util.Date;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class DateType extends BaseType<Date> {
+public class DateType extends BaseType<Date> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 936566410691643144L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.DATE_STATIC_REF + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Date";
     
     public DateType() {
         super(Normalizer.DATE_NORMALIZER);
@@ -32,5 +34,10 @@ public class DateType extends BaseType<Date> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/GeoLatType.java
+++ b/src/main/java/datawave/data/type/GeoLatType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class GeoLatType extends BaseType<String> {
+public class GeoLatType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -2775239290833908032L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Latitude";
     
     public GeoLatType() {
         super(Normalizer.GEO_LAT_NORMALIZER);
@@ -19,5 +21,10 @@ public class GeoLatType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/GeoLonType.java
+++ b/src/main/java/datawave/data/type/GeoLonType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class GeoLonType extends BaseType<String> {
+public class GeoLonType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 8912983433360105604L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Longitude";
     
     public GeoLonType() {
         super(Normalizer.GEO_LON_NORMALIZER);
@@ -19,5 +21,10 @@ public class GeoLonType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/GeoType.java
+++ b/src/main/java/datawave/data/type/GeoType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class GeoType extends BaseType<String> {
+public class GeoType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 8429780512238258642L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Geo";
     
     public GeoType() {
         super(Normalizer.GEO_NORMALIZER);
@@ -19,5 +21,10 @@ public class GeoType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/GeometryType.java
+++ b/src/main/java/datawave/data/type/GeometryType.java
@@ -5,14 +5,16 @@ import java.util.List;
 import datawave.data.normalizer.Normalizer;
 import datawave.data.normalizer.OneToManyNormalizer;
 import datawave.data.type.util.Geometry;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
 /**
  * Provides inclusive support for all geometry types. OneToManyNormalizer support is needed as lines and polygons are likely to produce multiple normalized
  * values during ingest.
  */
-public class GeometryType extends AbstractGeometryType<Geometry> implements OneToManyNormalizerType<Geometry> {
+public class GeometryType extends AbstractGeometryType<Geometry> implements OneToManyNormalizerType<Geometry>, TypePrettyNameSupplier {
     
     protected List<String> normalizedValues;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Geometry";
     
     public GeometryType() {
         super(Normalizer.GEOMETRY_NORMALIZER);
@@ -39,5 +41,10 @@ public class GeometryType extends AbstractGeometryType<Geometry> implements OneT
     @Override
     public boolean expandAtQueryTime() {
         return false;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/HexStringType.java
+++ b/src/main/java/datawave/data/type/HexStringType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class HexStringType extends BaseType<String> {
+public class HexStringType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -3480716807342380164L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Hex String";
     
     public HexStringType() {
         super(Normalizer.HEX_STRING_NORMALIZER);
@@ -19,5 +21,10 @@ public class HexStringType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/IpAddressType.java
+++ b/src/main/java/datawave/data/type/IpAddressType.java
@@ -5,11 +5,13 @@ import datawave.data.normalizer.Normalizer;
 import datawave.data.type.util.IpAddress;
 import datawave.data.type.util.IpV4Address;
 import datawave.data.type.util.IpV6Address;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class IpAddressType extends BaseType<IpAddress> {
+public class IpAddressType extends BaseType<IpAddress> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -6512690642978201801L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "IP Address";
     
     public IpAddressType() {
         super(Normalizer.IP_ADDRESS_NORMALIZER);
@@ -41,5 +43,10 @@ public class IpAddressType extends BaseType<IpAddress> {
             ipSize = Sizer.getObjectSize(delegate) + Sizer.REFERENCE;
         }
         return base + ipSize;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/IpV4AddressType.java
+++ b/src/main/java/datawave/data/type/IpV4AddressType.java
@@ -4,11 +4,13 @@ import datawave.data.normalizer.Normalizer;
 import datawave.data.type.util.IpAddress;
 import datawave.data.type.util.IpV4Address;
 import datawave.data.type.util.IpV6Address;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class IpV4AddressType extends BaseType<IpAddress> {
+public class IpV4AddressType extends BaseType<IpAddress> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 7214683578627273557L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "IPv4 Address";
     
     public IpV4AddressType() {
         super(Normalizer.IP_ADDRESS_NORMALIZER);
@@ -32,5 +34,10 @@ public class IpV4AddressType extends BaseType<IpAddress> {
             ipSize = Sizer.getObjectSize(delegate) + Sizer.REFERENCE;
         }
         return base + ipSize;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/LcNoDiacriticsListType.java
+++ b/src/main/java/datawave/data/type/LcNoDiacriticsListType.java
@@ -1,8 +1,11 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class LcNoDiacriticsListType extends ListType {
+public class LcNoDiacriticsListType extends ListType implements TypePrettyNameSupplier {
+    
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Text List";
     
     public LcNoDiacriticsListType() {
         super(Normalizer.LC_NO_DIACRITICS_NORMALIZER);
@@ -12,4 +15,8 @@ public class LcNoDiacriticsListType extends ListType {
         super(delegateString, Normalizer.LC_NO_DIACRITICS_NORMALIZER);
     }
     
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
+    }
 }

--- a/src/main/java/datawave/data/type/LcNoDiacriticsType.java
+++ b/src/main/java/datawave/data/type/LcNoDiacriticsType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class LcNoDiacriticsType extends BaseType<String> {
+public class LcNoDiacriticsType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -6219894926244790742L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Text";
     
     public LcNoDiacriticsType() {
         super(Normalizer.LC_NO_DIACRITICS_NORMALIZER);
@@ -23,5 +25,10 @@ public class LcNoDiacriticsType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/LcType.java
+++ b/src/main/java/datawave/data/type/LcType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class LcType extends BaseType<String> {
+public class LcType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -5102714749195917406L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Lower Case Text";
     
     public LcType() {
         super(Normalizer.LC_NORMALIZER);
@@ -23,5 +25,10 @@ public class LcType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/ListType.java
+++ b/src/main/java/datawave/data/type/ListType.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 import datawave.util.StringUtils;
 
-public abstract class ListType extends BaseType implements OneToManyNormalizerType {
+public abstract class ListType extends BaseType implements OneToManyNormalizerType, TypePrettyNameSupplier {
     protected static final String delimiter = ",|;";
     List<String> normalizedValues;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "List";
     
     public ListType(Normalizer normalizer) {
         super(normalizer);
@@ -47,5 +49,10 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
     @Override
     public boolean expandAtQueryTime() {
         return false;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/MacAddressType.java
+++ b/src/main/java/datawave/data/type/MacAddressType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class MacAddressType extends BaseType<String> {
+public class MacAddressType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -6743560287574389073L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "MAC Address";
     
     public MacAddressType() {
         super(Normalizer.MAC_ADDRESS_NORMALIZER);
@@ -19,5 +21,10 @@ public class MacAddressType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/NumberListType.java
+++ b/src/main/java/datawave/data/type/NumberListType.java
@@ -1,8 +1,11 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class NumberListType extends ListType {
+public class NumberListType extends ListType implements TypePrettyNameSupplier {
+    
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Number List";
     
     public NumberListType() {
         super(Normalizer.NUMBER_NORMALIZER);
@@ -11,5 +14,10 @@ public class NumberListType extends ListType {
     @Override
     public boolean expandAtQueryTime() {
         return true;
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/NumberType.java
+++ b/src/main/java/datawave/data/type/NumberType.java
@@ -3,11 +3,13 @@ package datawave.data.type;
 import java.math.BigDecimal;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class NumberType extends BaseType<BigDecimal> {
+public class NumberType extends BaseType<BigDecimal> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 1398451215614987988L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.BIGDECIMAL_STATIC_REF + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Number";
     
     public NumberType() {
         super(Normalizer.NUMBER_NORMALIZER);
@@ -23,5 +25,10 @@ public class NumberType extends BaseType<BigDecimal> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/PointType.java
+++ b/src/main/java/datawave/data/type/PointType.java
@@ -2,13 +2,21 @@ package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
 import datawave.data.type.util.Point;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
 /**
  * Provides support for point geometry types. Other geometry types are not compatible with this type.
  */
-public class PointType extends AbstractGeometryType<Point> {
+public class PointType extends AbstractGeometryType<Point> implements TypePrettyNameSupplier {
+    
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Point";
     
     public PointType() {
         super(Normalizer.POINT_NORMALIZER);
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/RawDateType.java
+++ b/src/main/java/datawave/data/type/RawDateType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class RawDateType extends BaseType<String> {
+public class RawDateType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 936566410691643144L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Raw Date";
     
     public RawDateType() {
         super(Normalizer.RAW_DATE_NORMALIZER);
@@ -24,5 +26,10 @@ public class RawDateType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/StringType.java
+++ b/src/main/java/datawave/data/type/StringType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class StringType extends BaseType<String> {
+public class StringType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = 8143572646109171126L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "String";
     
     public StringType() {
         super(Normalizer.LC_NO_DIACRITICS_NORMALIZER);
@@ -19,5 +21,10 @@ public class StringType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/TrimLeadingZerosType.java
+++ b/src/main/java/datawave/data/type/TrimLeadingZerosType.java
@@ -1,11 +1,13 @@
 package datawave.data.type;
 
 import datawave.data.normalizer.Normalizer;
+import datawave.data.type.util.TypePrettyNameSupplier;
 
-public class TrimLeadingZerosType extends BaseType<String> {
+public class TrimLeadingZerosType extends BaseType<String> implements TypePrettyNameSupplier {
     
     private static final long serialVersionUID = -7425014359719165469L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF * 2 + Sizer.REFERENCE;
+    private static final String DATA_DICTIONARY_TYPE_NAME = "Trimmed Number";
     
     public TrimLeadingZerosType() {
         super(Normalizer.TRIM_LEADING_ZEROS_NORMALIZER);
@@ -19,5 +21,10 @@ public class TrimLeadingZerosType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+    }
+    
+    @Override
+    public String getDataDictionaryTypeValue() {
+        return DATA_DICTIONARY_TYPE_NAME;
     }
 }

--- a/src/main/java/datawave/data/type/util/TypePrettyNameSupplier.java
+++ b/src/main/java/datawave/data/type/util/TypePrettyNameSupplier.java
@@ -1,0 +1,7 @@
+package datawave.data.type.util;
+
+public interface TypePrettyNameSupplier {
+    String getDataDictionaryTypeValue();
+    
+    public static final String DEFAULT_DATA_DICTIONARY_NAME = "Default";
+}


### PR DESCRIPTION
This PR adds Type descriptions into the classes themselves. These descriptions are used when populating the 'Types' field in the Data Dictionary.

If a type does not implement `TypePrettyNameSupplier` (the new interface that is utilized when populating the 'Types' field), then it will use the default value provided in the interface. This is why some classes do not include these changes.

Related to [dw-dictionary-service PR 23](https://github.com/NationalSecurityAgency/datawave-dictionary-service/pull/23)