### PR TITLE
Add TypeFactory with internal type cache

### DIFF
--- a/src/main/java/datawave/data/type/Type.java
+++ b/src/main/java/datawave/data/type/Type.java
@@ -39,10 +39,13 @@ public interface Type<T extends Comparable<T>> extends Comparable<Type<T>> {
     
     class Factory {
         
+        private Factory() {
+            // private constructor to enforce static access
+        }
+        
         public static Type<?> createType(String datawaveTypeClassName) {
-            
             try {
-                return (Type<?>) Class.forName(datawaveTypeClassName).newInstance();
+                return (Type<?>) Class.forName(datawaveTypeClassName).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new IllegalArgumentException("Error creating instance of class " + datawaveTypeClassName + ':' + e.getLocalizedMessage(), e);
             }

--- a/src/main/java/datawave/data/type/TypeFactory.java
+++ b/src/main/java/datawave/data/type/TypeFactory.java
@@ -1,0 +1,44 @@
+package datawave.data.type;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+/**
+ * TypeFactory that uses an internal loading cache to limit new Type objects
+ */
+public class TypeFactory {
+    
+    //  @formatter:off
+    private final LoadingCache<String, Type<?>> typeCache = CacheBuilder.newBuilder()
+                    .maximumSize(128)
+                    .expireAfterWrite(15, TimeUnit.MINUTES)
+                    .build(new CacheLoader<>() {
+                        @Override public Type<?> load(String className) throws Exception {
+                            Class<?> clazz = Class.forName(className);
+                            return (Type<?>) clazz.getDeclaredConstructor().newInstance();
+                        }
+                    });
+    //  @formatter:on
+    
+    public TypeFactory() {
+        // empty constructor
+    }
+    
+    /**
+     * Create a {@link Type} for the given class name
+     * 
+     * @param className
+     *            the class name
+     * @return the Type
+     */
+    public Type<?> createType(String className) {
+        try {
+            return typeCache.get(className);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error creating instance of class " + className);
+        }
+    }
+}

--- a/src/main/java/datawave/data/type/TypeFactory.java
+++ b/src/main/java/datawave/data/type/TypeFactory.java
@@ -11,20 +11,39 @@ import com.google.common.cache.LoadingCache;
  */
 public class TypeFactory {
     
-    //  @formatter:off
-    private final LoadingCache<String, Type<?>> typeCache = CacheBuilder.newBuilder()
-                    .maximumSize(128)
-                    .expireAfterWrite(15, TimeUnit.MINUTES)
-                    .build(new CacheLoader<>() {
-                        @Override public Type<?> load(String className) throws Exception {
-                            Class<?> clazz = Class.forName(className);
-                            return (Type<?>) clazz.getDeclaredConstructor().newInstance();
-                        }
-                    });
-    //  @formatter:on
+    private static final int DEFAULT_SIZE = 32;
+    private static final int DEFAULT_TIMEOUT_MINUTES = 15;
     
+    private final LoadingCache<String,Type<?>> typeCache;
+    
+    /**
+     * Constructor that uses the default size and timeout
+     */
     public TypeFactory() {
-        // empty constructor
+        this(DEFAULT_SIZE, DEFAULT_TIMEOUT_MINUTES);
+    }
+    
+    /**
+     * Constructor that uses custom size and timeout arguments
+     * 
+     * @param size
+     *            the cache size
+     * @param timeout
+     *            the timeout in minutes
+     */
+    public TypeFactory(int size, int timeout) {
+        //  @formatter:off
+        typeCache = CacheBuilder.newBuilder()
+                        .maximumSize(size)
+                        .expireAfterWrite(timeout, TimeUnit.MINUTES)
+                        .build(new CacheLoader<>() {
+                            @Override
+                            public Type<?> load(String className) throws Exception {
+                                Class<?> clazz = Class.forName(className);
+                                return (Type<?>) clazz.getDeclaredConstructor().newInstance();
+                            }
+                        });
+        //  @formatter:on
     }
     
     /**
@@ -40,5 +59,14 @@ public class TypeFactory {
         } catch (Exception e) {
             throw new IllegalStateException("Error creating instance of class " + className);
         }
+    }
+    
+    /**
+     * Expose current cache size
+     * 
+     * @return the current cache size
+     */
+    public long getCacheSize() {
+        return typeCache.size();
     }
 }

--- a/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -1,5 +1,6 @@
 package datawave.data.type;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -7,11 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TypeFactoryTest {
     
-    private final TypeFactory typeFactory = new TypeFactory();
+    private TypeFactory typeFactory;
+    
+    @BeforeEach
+    public void before() {
+        typeFactory = new TypeFactory();
+    }
     
     @Test
     public void testWithCorrectType() {
@@ -32,6 +39,24 @@ public class TypeFactoryTest {
         Type<?> typeTwo = factory.createType(LcType.class.getName());
         
         assertSame(typeOne, typeTwo);
+    }
+    
+    @Test
+    public void testTypeFactoryCustomSize() {
+        TypeFactory factory = new TypeFactory(1, 15);
+        
+        Type<?> typeOne = factory.createType(LcType.class.getName());
+        Type<?> typeTwo = factory.createType(IpAddressType.class.getName());
+        Type<?> typeThree = factory.createType(IpAddressType.class.getName());
+        Type<?> typeFour = factory.createType(LcType.class.getName());
+        
+        // same type created in a row with a cache size of one will return the same type instance
+        assertSame(typeTwo, typeThree);
+        
+        // same type created with other types between will return different instances
+        assertNotSame(typeOne, typeFour);
+        
+        assertEquals(1, factory.getCacheSize());
     }
     
     @Test
@@ -64,6 +89,8 @@ public class TypeFactoryTest {
         for (String typeClassName : typeClassNames) {
             assertTypeCreation(typeClassName);
         }
+        
+        assertEquals(20, typeFactory.getCacheSize());
     }
     
     /**

--- a/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -1,21 +1,89 @@
 package datawave.data.type;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 public class TypeFactoryTest {
     
+    private final TypeFactory typeFactory = new TypeFactory();
+    
     @Test
-    public void testWithCorrectType() throws Exception {
+    public void testWithCorrectType() {
         Type<?> type = Type.Factory.createType("datawave.data.type.LcType");
-        assertTrue(type instanceof LcType);
+        assertInstanceOf(LcType.class, type);
     }
     
     @Test
-    public void testWithIncorrectType() throws Exception {
+    public void testWithIncorrectType() {
         assertThrows(IllegalArgumentException.class, () -> Type.Factory.createType("datawave.ingest.data.normalizer.LcNoDiacriticsNormalizer"));
+    }
+    
+    @Test
+    public void testTypeFactoryWithCache() {
+        TypeFactory factory = new TypeFactory();
+        
+        Type<?> typeOne = factory.createType(LcType.class.getName());
+        Type<?> typeTwo = factory.createType(LcType.class.getName());
+        
+        assertSame(typeOne, typeTwo);
+    }
+    
+    @Test
+    public void testAllTypesAllFactories() {
+        // AbstractGeometryType, BaseType and ListType are technically all abstract types and cannot be created
+        
+        //  @formatter:off
+        List<String> typeClassNames = List.of(DateType.class.getName(),
+                        GeoLatType.class.getName(),
+                        GeoLonType.class.getName(),
+                        GeometryType.class.getName(),
+                        GeoType.class.getName(),
+                        HexStringType.class.getName(),
+                        HitTermType.class.getName(),
+                        IpAddressType.class.getName(),
+                        IpV4AddressType.class.getName(),
+                        LcNoDiacriticsListType.class.getName(),
+                        LcNoDiacriticsType.class.getName(),
+                        LcType.class.getName(),
+                        MacAddressType.class.getName(),
+                        NoOpType.class.getName(),
+                        NumberListType.class.getName(),
+                        NumberType.class.getName(),
+                        PointType.class.getName(),
+                        RawDateType.class.getName(),
+                        StringType.class.getName(),
+                        TrimLeadingZerosType.class.getName());
+        //  @formatter:on
+        
+        for (String typeClassName : typeClassNames) {
+            assertTypeCreation(typeClassName);
+        }
+    }
+    
+    /**
+     * Assert that the same Type is created via the internal {@link Type.Factory} and the {@link TypeFactory}.
+     * <p>
+     * Also asserts that multiple calls to {@link TypeFactory#createType(String)} return the same instance.
+     *
+     * @param typeClassName
+     *            the class name for a Type
+     */
+    private void assertTypeCreation(String typeClassName) {
+        Type<?> internalCreate = Type.Factory.createType(typeClassName);
+        
+        Type<?> factoryCreateOne = typeFactory.createType(typeClassName);
+        Type<?> factoryCreateTwo = typeFactory.createType(typeClassName);
+        
+        assertSame(factoryCreateOne, factoryCreateTwo, "TypeFactory should have returned the same instance");
+        
+        assertNotSame(internalCreate, factoryCreateOne, "Type.Factory and TypeFactory should have returned different instances");
+        assertNotSame(internalCreate, factoryCreateTwo, "Type.Factory and TypeFactory should have returned different instances");
     }
     
 }


### PR DESCRIPTION
- Add TypeFactory that uses internal cache to avoid creating extra instances of a Type. 
- Update Type creation to avoid use of deprecated Class.newInstance()